### PR TITLE
Update dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license='Apache 2.0',
     packages=find_packages(),
     install_requires=[
-        'absl-py==0.8.1',
+        'absl-py>=0.8.1',
         'numpy>=1.7',
         'tf-nightly',
         'tensorflow-datasets>=1.3.0',
@@ -36,6 +36,7 @@ setup(
         ],
         'models': [
             'tf-models-nightly',  # Needed for BERT, depends on tf-nightly.
+            'tensorflow-probability',
             'edward2 @ git+https://github.com/google/edward2.git#egg=edward2[tf-nightly]',
         ],
         'tests': ['pylint>=1.9.0'],


### PR DESCRIPTION
I just tried installing the framework and noticed the following dependency issues:
- `abs-py==0.8.1` conflicts with `tf-nightly`
- `tensorflow-probability` is required for `edward2`

Thanks for the package!