### PR TITLE
Remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: python
 git:
   depth: 10


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).