### PR TITLE
Remove tf-nightly dependency of the models extra (for JAX only users)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
              'git+https://github.com/google-research/robustness_metrics.git'
              '#egg=robustness_metrics'),
             'scipy',
-            'tf-models-nightly',  # Needed for BERT, depends on tf-nightly.
-            'tfp-nightly',
         ],
         'datasets': [
             'librosa',  # Needed for speech_commands dataset
@@ -66,6 +64,8 @@ setup(
             'tb-nightly',
             'tf-nightly',
             'tfa-nightly',
+            'tf-models-nightly',  # Needed for BERT
+            'tfp-nightly',
         ],
         'tests': ['pylint>=1.9.0'],
         'torch': [


### PR DESCRIPTION
Move tf-nightly dep of [models] to the tensorflow backend section such that JAX only users don't depend on tf-nightly.