### PR TITLE
External CIFAR-10 Fine-Tuning

### DIFF
--- a/baselines/jft/deterministic.py
+++ b/baselines/jft/deterministic.py
@@ -50,8 +50,8 @@ import train_utils  # local file import
 fewshot = None
 
 
-ml_collections.config_flags.DEFINE_config_file(
-    'config', None, 'Training configuration.', lock_config=True)
+# ml_collections.config_flags.DEFINE_config_file(
+#     'config', None, 'Training configuration.', lock_config=True)
 flags.DEFINE_string('output_dir', default=None, help='Work unit directory.')
 flags.DEFINE_integer(
     'num_cores', default=None, help='Unused. How many devices being used.')
@@ -66,7 +66,9 @@ FLAGS = flags.FLAGS
 def main(argv):
   del argv
 
-  config = FLAGS.config
+  # config = FLAGS.config
+  from baselines.jft.experiments import imagenet21k_vit_base16_finetune_cifar10
+  config = imagenet21k_vit_base16_finetune_cifar10.get_config()
   output_dir = FLAGS.output_dir
 
   seed = config.get('seed', 0)

--- a/baselines/jft/experiments/imagenet21k_vit_base16_finetune_cifar10.py
+++ b/baselines/jft/experiments/imagenet21k_vit_base16_finetune_cifar10.py
@@ -42,7 +42,7 @@ def get_config():
   config.ood_split = 'test'
   config.ood_methods = ['msp', 'entropy', 'maha', 'rmaha']
 
-  BATCH_SIZE = 512  # pylint: disable=invalid-name
+  BATCH_SIZE = 256  # pylint: disable=invalid-name
   config.batch_size = BATCH_SIZE
 
   config.total_steps = 10_000
@@ -70,7 +70,8 @@ def get_config():
   # Model section
   # pre-trained model ckpt file
   # !!!  The below section should be modified per experiment
-  config.model_init = '/path/to/pretrained_model_ckpt.npz'
+  config.model_init = (
+    'gs://ub-data/ImageNet21k_ViT-B16_ImagetNet21k_ViT-B_16_28592399.npz')
   # Model definition to be copied from the pre-training config
   config.model = ml_collections.ConfigDict()
   config.model.patches = ml_collections.ConfigDict()

--- a/baselines/jft/input_utils.py
+++ b/baselines/jft/input_utils.py
@@ -30,9 +30,11 @@ import tensorflow_datasets as tfds
 def _get_dataset_builder(
     dataset: Union[str, tfds.core.DatasetBuilder],
     data_dir: Optional[str] = None) -> tfds.core.DatasetBuilder:
-  """Returns a dataset builder."""
+  """Returns a dataset builder, downloading and preparing the dataset
+  if retrieved by string."""
   if isinstance(dataset, str):
     dataset_builder = tfds.builder(dataset, data_dir=data_dir)
+    dataset_builder.download_and_prepare()
   elif isinstance(dataset, tfds.core.DatasetBuilder):
     dataset_builder = dataset
   else:

--- a/baselines/jft/input_utils.py
+++ b/baselines/jft/input_utils.py
@@ -30,11 +30,9 @@ import tensorflow_datasets as tfds
 def _get_dataset_builder(
     dataset: Union[str, tfds.core.DatasetBuilder],
     data_dir: Optional[str] = None) -> tfds.core.DatasetBuilder:
-  """Returns a dataset builder, downloading and preparing the dataset
-  if retrieved by string."""
+  """Returns a dataset builder."""
   if isinstance(dataset, str):
     dataset_builder = tfds.builder(dataset, data_dir=data_dir)
-    dataset_builder.download_and_prepare()
   elif isinstance(dataset, tfds.core.DatasetBuilder):
     dataset_builder = dataset
   else:

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
              'git+https://github.com/google-research/robustness_metrics.git'
              '#egg=robustness_metrics'),
             'scipy',
-            'tf-models-nightly',  # Needed for BERT, depends on tf-nightly.
-            'tfp-nightly',
         ],
         'datasets': [
             'librosa',  # Needed for speech_commands dataset
@@ -66,12 +64,20 @@ setup(
             'tb-nightly',
             'tf-nightly',
             'tfa-nightly',
+            'tf-models-nightly',  # Needed for BERT, depends on tf-nightly.
+            'tfp-nightly',
         ],
         'tests': ['pylint>=1.9.0'],
         'torch': [
             'torch',
             'torchvision',
         ],
+        'tpuvm': [
+            'tensorflow',
+            'clu',
+            'tensorflow-probability',
+            'tfds-nightly'
+        ]
     },
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ setup(
             'tensorflow',
             'clu',
             'tensorflow-probability',
+            # tfds-nightly needed due to a bug in v4.4.0
+            # “TypeError: '>' not supported between instances
+            #   of 'int' and 'SplitInfo'”
             'tfds-nightly'
         ]
     },


### PR DESCRIPTION
* **setup.py**
  * Following [Joost's PR](https://github.com/google/uncertainty-baselines/pull/575), remove nightly TensorFlow dependencies from the `models` addon to the `tensorflow` addon (which we don't need for this).
  * Add a `tpuvm` addon with some extra dependencies (e.g., a stable tensorflow release).
* **baselines/jft/deterministic.py**
  * Remove `ml_collections.config_flags` usage which is not yet supported. Replace with a direct config import.
* **baselines/jft/experiments/imagenet21k_vit_base16_finetune_cifar10.py** 
  * Halve the batch size from 512 to 256 (TPU v2-8 memory constraints).
  * Update the model checkpoint path to a location in the `marginalization-external-xgcp` Google Storage bucket.