### PR TITLE
Add segmenter be 

### DIFF
--- a/uncertainty_baselines/models/__init__.py
+++ b/uncertainty_baselines/models/__init__.py
@@ -91,6 +91,7 @@ except tf.errors.NotFoundError:
 try:
   # Try to import Segmenter models.
   from uncertainty_baselines.models.segmenter import segmenter_transformer
+  from uncertainty_baselines.models.segmenter_be import segmenter_be_transformer
 except ImportError:
   logging.warning('Skipped Segmenter models due to ImportError.', exc_info=True)
 except tf.errors.NotFoundError:

--- a/uncertainty_baselines/models/__init__.py
+++ b/uncertainty_baselines/models/__init__.py
@@ -90,8 +90,8 @@ except tf.errors.NotFoundError:
 # pylint: disable=g-import-not-at-top
 try:
   # Try to import Segmenter models.
-  from uncertainty_baselines.models.segmenter import segmenter_transformer
-  from uncertainty_baselines.models.segmenter_be import segmenter_be_transformer
+  from uncertainty_baselines.models.segmenter import SegVit
+  from uncertainty_baselines.models.segmenter_be import SegVitBE
 except ImportError:
   logging.warning('Skipped Segmenter models due to ImportError.', exc_info=True)
 except tf.errors.NotFoundError:

--- a/uncertainty_baselines/models/segmenter.py
+++ b/uncertainty_baselines/models/segmenter.py
@@ -23,235 +23,12 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import ml_collections
+from uncertainty_baselines.models import vit
 
 Array = Any
 PRNGKey = Any
 Shape = Tuple[int]
 Dtype = Any
-
-
-class IdentityLayer(nn.Module):
-  """Identity layer, convenient for giving a name to an array."""
-
-  @nn.compact
-  def __call__(self, x):
-    return x
-
-
-class AddPositionEmbs(nn.Module):
-  """Adds (optionally learned) positional embeddings to the inputs.
-
-  Attributes:
-    posemb_init: positional embedding initializer.
-  """
-  # TODO(kellybuchanan): check initialization,
-  # nn.initializers.normal(stddev=0.02) from BERT.
-  posemb_init: Callable[[PRNGKey, Shape, Dtype], Array]
-
-  @nn.compact
-  def __call__(self, inputs):
-    """Applies AddPositionEmbs module.
-
-    By default this layer uses a fixed sinusoidal embedding table. If a
-    learned position embedding is desired, pass an initializer to
-    posemb_init.
-
-    Args:
-      inputs: Inputs to the layer.
-
-    Returns:
-      Output tensor with shape `(bs, timesteps, in_dim)`.
-    """
-    # inputs.shape is (batch_size, seq_len, emb_dim).
-    assert inputs.ndim == 3, ('Number of dimensions should be 3,'
-                              ' but it is: %d' % inputs.ndim)
-    pos_emb_shape = (1, inputs.shape[1], inputs.shape[2])
-    pe = self.param('pos_embedding', self.posemb_init, pos_emb_shape)
-    return inputs + pe
-
-
-class MlpBlock(nn.Module):
-  """Transformer MLP / feed-forward block."""
-
-  mlp_dim: int
-  dtype: Dtype = jnp.float32
-  out_dim: Optional[int] = None
-  dropout_rate: float = 0.1
-  kernel_init: Callable[[PRNGKey, Shape, Dtype],
-                        Array] = nn.initializers.xavier_uniform()
-  bias_init: Callable[[PRNGKey, Shape, Dtype],
-                      Array] = nn.initializers.normal(stddev=1e-6)
-  use_bias: bool = True
-  precision: Optional[jax.lax.Precision] = None
-  activation_fn: Callable[[jnp.ndarray], jnp.ndarray] = nn.gelu
-
-  @nn.compact
-  def __call__(self, inputs, *, deterministic):
-    """Applies Transformer MlpBlock module."""
-    actual_out_dim = inputs.shape[-1] if self.out_dim is None else self.out_dim
-    x = nn.Dense(
-        features=self.mlp_dim,
-        dtype=self.dtype,
-        use_bias=self.use_bias,
-        kernel_init=self.kernel_init,
-        bias_init=self.bias_init,
-        precision=self.precision)(  # pytype: disable=wrong-arg-types
-            inputs)
-    x = self.activation_fn(x)
-    x = nn.Dropout(rate=self.dropout_rate)(x, deterministic=deterministic)
-    output = nn.Dense(
-        features=actual_out_dim,
-        dtype=self.dtype,
-        kernel_init=self.kernel_init,
-        bias_init=self.bias_init,
-        use_bias=self.use_bias,
-        precision=self.precision)(  # pytype: disable=wrong-arg-types
-            x)
-    output = nn.Dropout(
-        rate=self.dropout_rate)(
-            output, deterministic=deterministic)
-    return output
-
-
-class Encoder1DBlock(nn.Module):
-  """Transformer encoder layer.
-
-  Attributes:
-    inputs: input data.
-    mlp_dim: dimension of the mlp on top of attention block.
-    dtype: the dtype of the computation (default: float32).
-    dropout_rate: dropout rate.
-    attention_dropout_rate: dropout for attention heads.
-    deterministic: bool, deterministic or not (to apply dropout).
-    num_heads: Number of heads in nn.MultiHeadDotProductAttention
-    stochastic_depth: probability of dropping a layer linearly grows from 0 to
-      the provided value.
-
-  """
-
-  mlp_dim: int
-  num_heads: int
-  dtype: Dtype = jnp.float32
-  dropout_rate: float = 0.1
-  attention_dropout_rate: float = 0.1
-  stochastic_depth: float = 0.0
-
-  def get_stochastic_depth_mask(self, x: jnp.ndarray,
-                                deterministic: bool) -> jnp.ndarray:
-    """Generate the stochastic depth mask in order to apply layer-drop.
-
-    Args:
-      x: Input tensor.
-      deterministic: Weather we are in the deterministic mode (e.g inference
-        time) or not.
-
-    Returns:
-      Stochastic depth mask.
-    """
-    if not deterministic and self.stochastic_depth:
-      shape = (x.shape[0],) + (1,) * (x.ndim - 1)
-      return jax.random.bernoulli(
-          self.make_rng('dropout'), self.stochastic_depth, shape)
-    else:
-      return 0.0
-
-  @nn.compact
-  def __call__(self, inputs, *, deterministic):
-    """Applies Encoder1DBlock module.
-
-    Args:
-      inputs: Inputs to the layer.
-      deterministic: Dropout will not be applied when set to true.
-
-    Returns:
-      output after transformer encoder block.
-    """
-
-    # Attention block.
-    assert inputs.ndim == 3, f'Expected (batch, seq, hidden) got {inputs.shape}'
-    x = nn.LayerNorm(dtype=self.dtype, name='LayerNorm_0')(inputs)
-    x = nn.MultiHeadDotProductAttention(
-        dtype=self.dtype,
-        kernel_init=nn.initializers.xavier_uniform(),
-        broadcast_dropout=False,
-        deterministic=deterministic,
-        dropout_rate=self.attention_dropout_rate,
-        num_heads=self.num_heads,
-        name='MultiHeadDotProductAttention_1')(x, x)
-    x = nn.Dropout(rate=self.dropout_rate)(x, deterministic=deterministic)
-    x = x * (1.0 - self.get_stochastic_depth_mask(x, deterministic)) + inputs
-
-    # MLP block.
-    y = nn.LayerNorm(dtype=self.dtype, name='LayerNorm_2')(x)
-    y = MlpBlock(
-        mlp_dim=self.mlp_dim,
-        dtype=self.dtype,
-        name='MlpBlock_3',
-        dropout_rate=self.dropout_rate,
-        activation_fn=nn.gelu,
-        kernel_init=nn.initializers.xavier_uniform(),
-        bias_init=nn.initializers.normal(stddev=1e-6))(
-            y, deterministic=deterministic)
-
-    return y * (1.0 - self.get_stochastic_depth_mask(x, deterministic)) + x
-
-
-class Encoder(nn.Module):
-  """Transformer Model Encoder for sequence to sequence translation.
-
-  Attributes:
-    num_layers: number of layers
-    mlp_dim: dimension of the mlp on top of attention block
-    num_heads: Number of heads in nn.MultiHeadDotProductAttention
-    dropout_rate: dropout rate.
-    attention_dropout_rate: dropout rate in self attention.
-    stochastic_depth: probability of dropping a layer linearly grows from 0 to
-    the provided value. Our implementation of stochastic depth follows timm
-    library, which does per-example layer dropping and uses independent
-    dropping patterns for each skip-connection.
-    dtype: Dtype of activations.
-  """
-
-  num_layers: int
-  mlp_dim: int
-  num_heads: int
-  dropout_rate: float = 0.1
-  attention_dropout_rate: float = 0.1
-  stochastic_depth: float = 0.0
-  dtype: Any = jnp.float32
-
-  @nn.compact
-  def __call__(self, inputs: jnp.ndarray, *, train: bool = False):
-    """Applies Transformer model on the inputs.
-
-    Args:
-      inputs: Inputs to the layer.
-      train: Set to `True` when training.
-
-    Returns:
-      output of a transformer encoder.
-    """
-    assert inputs.ndim == 3  # (batch, len, emb)
-    x = AddPositionEmbs(
-        posemb_init=nn.initializers.normal(stddev=0.02),  # from BERT.
-        name='posembed_input')(
-            inputs)
-    x = nn.Dropout(rate=self.dropout_rate)(x, deterministic=not train)
-
-    # Input Encoder
-    for lyr in range(self.num_layers):
-      x = Encoder1DBlock(
-          mlp_dim=self.mlp_dim,
-          dropout_rate=self.dropout_rate,
-          attention_dropout_rate=self.attention_dropout_rate,
-          stochastic_depth=(lyr / max(self.num_layers - 1, 1)) *
-          self.stochastic_depth,
-          name=f'encoderblock_{lyr}',
-          num_heads=self.num_heads)(
-              x, deterministic=not train)
-    encoded = nn.LayerNorm(name='encoder_norm')(x)
-
-    return encoded
 
 
 class ViTBackbone(nn.Module):
@@ -299,7 +76,7 @@ class ViTBackbone(nn.Module):
       cls = jnp.tile(cls, [n, 1, 1])
       x = jnp.concatenate([cls, x], axis=1)
 
-    x = Encoder(name='Transformer',
+    x = vit.Encoder(name='Transformer',
                 mlp_dim=self.mlp_dim,
                 num_layers=self.num_layers,
                 num_heads=self.num_heads,
@@ -337,7 +114,7 @@ class SegVit(nn.Module):
           hidden_size=self.backbone_configs.hidden_size,
           dropout_rate=self.backbone_configs.dropout_rate,
           attention_dropout_rate=self.backbone_configs.attention_dropout_rate,
-          classifier='gap',
+          classifier=self.backbone_configs.classifier,
           name='backbone')(
               x, train=train)
     else:

--- a/uncertainty_baselines/models/segmenter.py
+++ b/uncertainty_baselines/models/segmenter.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Segmenter Vision Transformer (ViT) model.
 
 Based on scenic library implementation.
@@ -76,13 +75,14 @@ class ViTBackbone(nn.Module):
       cls = jnp.tile(cls, [n, 1, 1])
       x = jnp.concatenate([cls, x], axis=1)
 
-    x = vit.Encoder(name='Transformer',
-                mlp_dim=self.mlp_dim,
-                num_layers=self.num_layers,
-                num_heads=self.num_heads,
-                dropout_rate=self.dropout_rate,
-                attention_dropout_rate=self.attention_dropout_rate,
-                )(x, train=train)
+    x = vit.Encoder(
+        name='Transformer',
+        mlp_dim=self.mlp_dim,
+        num_layers=self.num_layers,
+        num_heads=self.num_heads,
+        dropout_rate=self.dropout_rate,
+        attention_dropout_rate=self.attention_dropout_rate,
+    )(x, train=train)
 
     out['transformed'] = x
 
@@ -142,19 +142,3 @@ class SegVit(nn.Module):
         x.shape[:-1])
 
     return x, out
-
-
-def segmenter_transformer(num_classes: int,
-                          patches: Any,
-                          backbone_configs: Any,
-                          decoder_configs: Any
-                          ):
-  """Builds a Vision Transformer (ViT) model."""
-  # TODO(dusenberrymw): Add API docs once config dict in VisionTransformer is
-  # cleaned up.
-  return SegVit(
-      num_classes=num_classes,
-      patches=patches,
-      backbone_configs=backbone_configs,
-      decoder_configs=decoder_configs,
-    )

--- a/uncertainty_baselines/models/segmenter_be.py
+++ b/uncertainty_baselines/models/segmenter_be.py
@@ -1,0 +1,211 @@
+# coding=utf-8
+# Copyright 2022 The Uncertainty Baselines Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Segmenter Vision Transformer (ViT) model.
+
+Based on scenic library implementation.
+"""
+from typing import Any, Callable, Optional, Tuple, Sequence, Iterable
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import ml_collections
+from uncertainty_baselines.models import vit_batchensemble, segmenter
+import edward2.jax as ed
+
+Array = Any
+PRNGKey = Any
+Shape = Tuple[int]
+DType = type(jnp.float32)
+
+InitializeFn = Callable[[jnp.ndarray, Iterable[int], DType], jnp.ndarray]
+
+class ViTBackboneBE(nn.Module):
+  """Vision Transformer model backbone (everything except the head).
+
+  Edited from VisionTransformer.
+  """
+
+  mlp_dim: int
+  num_layers: int
+  num_heads: int
+  patches: ml_collections.ConfigDict
+  hidden_size: int
+  ens_size: int
+  random_sign_init: float
+  be_layers: Optional[Sequence[int]] = None
+  dropout_rate: float = 0.1
+  attention_dropout_rate: float = 0.1
+  classifier: str = 'gap'
+
+  @nn.compact
+  def __call__(self, inputs, *, train: bool):
+    out = {}
+
+    x = inputs
+    n, h, w, c = x.shape
+
+    # We can merge s2d+emb into a single conv; it's the same.
+    x = nn.Conv(
+        features=self.hidden_size,
+        kernel_size=self.patches.size,
+        strides=self.patches.size,
+        padding='VALID',
+        name='embedding')(
+            x)
+
+    # Here, x is a grid of embeddings.
+    # TODO(dusenberrymw): Switch to self.sow(.).
+    out['stem'] = x
+
+    # Transformer.
+    n, h, w, c = x.shape
+    x = jnp.reshape(x, [n, h * w, c])
+
+    # If we want to add a class token, add it here.
+    if self.classifier == 'token':
+      cls = self.param('cls', nn.initializers.zeros, (1, 1, c))
+      cls = jnp.tile(cls, [n, 1, 1])
+      x = jnp.concatenate([cls, x], axis=1)
+
+    x, extra_info = vit_batchensemble.BatchEnsembleEncoder(
+        name='Transformer',
+        mlp_dim=self.mlp_dim,
+        num_layers=self.num_layers,
+        num_heads=self.num_heads,
+        dropout_rate=self.dropout_rate,
+        attention_dropout_rate=self.attention_dropout_rate,
+        ens_size=self.ens_size,
+        random_sign_init=self.random_sign_init,
+        be_layers=self.be_layers,
+        train=train,
+    )(x)
+
+    out.update(extra_info)
+    out['transformed'] = x
+
+    return x, out
+
+
+class SegVitBE(nn.Module):
+  """Segmentation model with ViT backbone and decoder."""
+
+  num_classes: int
+  patches: ml_collections.ConfigDict
+  backbone_configs: ml_collections.ConfigDict
+  decoder_configs: ml_collections.ConfigDict
+  head_kernel_init: InitializeFn = nn.initializers.zeros
+
+  @nn.compact
+  def __call__(self, x: jnp.ndarray, *, train: bool, debug: bool = False):
+    input_shape = x.shape
+    b, h, w, _ = input_shape
+
+    fh, fw = self.patches.size
+    gh, gw = h // fh, w // fw
+
+    if self.backbone_configs.type == 'vit' and self.decoder_configs.type == 'linear':
+      assert self.backbone_configs.ens_size == 1
+
+    if self.backbone_configs.type == 'vit' and self.decoder_configs.type == 'linear_be':
+      raise NotImplementedError('Configuration with encoder {} and decoder {} is not implemented'.format(
+          self.backbone_configs.type,
+          self.decoder_configs.type,
+      ))
+
+    if self.backbone_configs.type == 'vit':
+      x, out = segmenter.ViTBackbone(
+          mlp_dim=self.backbone_configs.mlp_dim,
+          num_layers=self.backbone_configs.num_layers,
+          num_heads=self.backbone_configs.num_heads,
+          patches=self.patches,
+          hidden_size=self.backbone_configs.hidden_size,
+          dropout_rate=self.backbone_configs.dropout_rate,
+          attention_dropout_rate=self.backbone_configs.attention_dropout_rate,
+          classifier=self.backbone_configs.classifier,
+          name='backbone')(
+              x, train=train)
+    elif self.backbone_configs.type == 'vit_be':
+      # import pdb; pdb.set_trace()
+      x, out = ViTBackboneBE(
+          mlp_dim=self.backbone_configs.mlp_dim,
+          num_layers=self.backbone_configs.num_layers,
+          num_heads=self.backbone_configs.num_heads,
+          patches=self.patches,
+          hidden_size=self.backbone_configs.hidden_size,
+          dropout_rate=self.backbone_configs.dropout_rate,
+          attention_dropout_rate=self.backbone_configs.attention_dropout_rate,
+          classifier=self.backbone_configs.classifier,
+          ens_size=self.backbone_configs.ens_size,
+          random_sign_init=self.backbone_configs.random_sign_init,
+          be_layers=self.backbone_configs.be_layers,
+          name='backbone')(
+              x, train=train)
+    else:
+      raise ValueError(f'Unknown backbone: {self.backbone_configs.type}.')
+
+    if self.decoder_configs.type == 'linear':
+      output_projection = nn.Dense(
+        self.num_classes,
+        kernel_init=nn.initializers.zeros,
+        name='output_projection')
+    elif self.decoder_configs.type == 'linear_be':
+      output_projection = ed.nn.DenseBatchEnsemble(
+          self.num_classes,
+          self.backbone_configs.ens_size,
+          activation=None,
+          alpha_init=ed.nn.utils.make_sign_initializer(
+              self.backbone_configs.get("random_sign_init")),
+          gamma_init=ed.nn.utils.make_sign_initializer(
+              self.backbone_configs.get("random_sign_init")),
+          kernel_init=self.head_kernel_init,
+          name="output_projection_be")
+    else:
+      raise ValueError(
+          f'Decoder type {self.decoder_configs.type} is not defined.')
+
+    ens_size = self.backbone_configs.get("ens_size")
+
+    # Linear head only, like Segmenter baseline:
+    # https://arxiv.org/abs/2105.05633
+    x = jnp.reshape(x, [b*ens_size, gh, gw, -1])
+    x = output_projection(x)
+
+    # Resize bilinearly:
+    x = jax.image.resize(x, [b*ens_size, h, w, x.shape[-1]], 'linear')
+    out['logits'] = x
+
+    new_input_shape = tuple([input_shape[0]*ens_size,] + list(input_shape[1:-1]))
+    assert new_input_shape == x.shape[:-1], (
+        'BE Input and output shapes do not match: %d vs. %d.', new_input_shape,
+        x.shape[:-1])
+
+    return x, out
+
+
+def segmenter_be_transformer(num_classes: int,
+                          patches: Any,
+                          backbone_configs: Any,
+                          decoder_configs: Any
+                          ):
+  """Builds a Segmenter BE model."""
+
+  return SegVitBE(
+      num_classes=num_classes,
+      patches=patches,
+      backbone_configs=backbone_configs,
+      decoder_configs=decoder_configs,
+    )

--- a/uncertainty_baselines/models/segmenter_be_test.py
+++ b/uncertainty_baselines/models/segmenter_be_test.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+# Copyright 2022 The Uncertainty Baselines Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the segmenter ViT model."""
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+import ml_collections
+import uncertainty_baselines as ub
+
+
+class SegVitBETest(parameterized.TestCase):
+
+  @parameterized.parameters(
+    (2, 16, 224, 224, 'vit', 'linear', 1),
+    (2, 16, 224, 224, 'vit_be', 'linear', 3),
+    (2, 16, 224, 224, 'vit_be', 'linear_be', 3),
+  )
+  def test_segmenter_be_transformer(self, num_classes, hidden_size, img_h, img_w,
+                                 encoder_type, decoder_type, ens_size):
+    # VisionTransformer.
+    config = ml_collections.ConfigDict()
+
+    config.num_classes = num_classes
+
+    config.patches = ml_collections.ConfigDict()
+    config.patches.size = [4, 4]
+
+    config.backbone_configs = ml_collections.ConfigDict()
+    config.backbone_configs.type = encoder_type
+    config.backbone_configs.hidden_size = hidden_size
+    config.backbone_configs.attention_dropout_rate = 0.
+    config.backbone_configs.dropout_rate = 0.
+    config.backbone_configs.mlp_dim = 2
+    config.backbone_configs.num_heads = 1
+    config.backbone_configs.num_layers = 1
+    config.backbone_configs.classifier = 'gap'
+
+    config.decoder_configs = ml_collections.ConfigDict()
+    config.decoder_configs.type = decoder_type
+
+    # BE params
+    config.backbone_configs.ens_size = ens_size
+    config.backbone_configs.random_sign_init = -0.5
+    config.backbone_configs.be_layers = (0,)
+
+    num_examples = 2
+    inputs = jnp.ones([num_examples, img_h, img_w, 3], jnp.float32)
+    model = ub.models.segmenter_be_transformer(**config)
+    key = jax.random.PRNGKey(0)
+    variables = model.init(key, inputs, train=False)
+
+    logits, outputs = model.apply(variables, inputs, train=False)
+
+    self.assertEqual(logits.shape, (num_examples*ens_size, img_h, img_w, num_classes))
+
+    self.assertEqual(
+        set(outputs.keys()),
+        set(('stem', 'transformed', 'logits')))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/uncertainty_baselines/models/segmenter_be_test.py
+++ b/uncertainty_baselines/models/segmenter_be_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for the segmenter ViT model."""
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,12 +24,13 @@ import uncertainty_baselines as ub
 class SegVitBETest(parameterized.TestCase):
 
   @parameterized.parameters(
-    (2, 16, 224, 224, 'vit', 'linear', 1),
-    (2, 16, 224, 224, 'vit_be', 'linear', 3),
-    (2, 16, 224, 224, 'vit_be', 'linear_be', 3),
+      (2, 16, 224, 224, 'vit', 'linear', 1),
+      (2, 16, 224, 224, 'vit_be', 'linear', 3),
+      (2, 16, 224, 224, 'vit_be', 'linear_be', 3),
   )
-  def test_segmenter_be_transformer(self, num_classes, hidden_size, img_h, img_w,
-                                 encoder_type, decoder_type, ens_size):
+  def test_segmenter_be_transformer(self, num_classes, hidden_size, img_h,
+                                    img_w, encoder_type, decoder_type,
+                                    ens_size):
     # VisionTransformer.
     config = ml_collections.ConfigDict()
 
@@ -59,17 +59,17 @@ class SegVitBETest(parameterized.TestCase):
 
     num_examples = 2
     inputs = jnp.ones([num_examples, img_h, img_w, 3], jnp.float32)
-    model = ub.models.segmenter_be_transformer(**config)
+    model = ub.models.SegVitBE(**config)
     key = jax.random.PRNGKey(0)
     variables = model.init(key, inputs, train=False)
 
     logits, outputs = model.apply(variables, inputs, train=False)
 
-    self.assertEqual(logits.shape, (num_examples*ens_size, img_h, img_w, num_classes))
+    self.assertEqual(logits.shape,
+                     (num_examples * ens_size, img_h, img_w, num_classes))
 
     self.assertEqual(
-        set(outputs.keys()),
-        set(('stem', 'transformed', 'logits')))
+        set(outputs.keys()), set(('stem', 'transformed', 'logits')))
 
 
 if __name__ == '__main__':

--- a/uncertainty_baselines/models/segmenter_test.py
+++ b/uncertainty_baselines/models/segmenter_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for the segmenter ViT model."""
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,8 +24,7 @@ import uncertainty_baselines as ub
 class SegVitTest(parameterized.TestCase):
 
   @parameterized.parameters(
-      (2, 16, 224, 224),
-  )
+      (2, 16, 224, 224),)
   def test_segmenter_transformer(self, num_classes, hidden_size, img_h, img_w):
     # VisionTransformer.
     config = ml_collections.ConfigDict()
@@ -51,7 +49,7 @@ class SegVitTest(parameterized.TestCase):
 
     num_examples = 2
     inputs = jnp.ones([num_examples, img_h, img_w, 3], jnp.float32)
-    model = ub.models.segmenter_transformer(**config)
+    model = ub.models.SegVit(**config)
     key = jax.random.PRNGKey(0)
     variables = model.init(key, inputs, train=False)
 
@@ -59,8 +57,7 @@ class SegVitTest(parameterized.TestCase):
 
     self.assertEqual(logits.shape, (num_examples, img_h, img_w, num_classes))
     self.assertEqual(
-        set(outputs.keys()),
-        set(('stem', 'transformed', 'logits')))
+        set(outputs.keys()), set(('stem', 'transformed', 'logits')))
 
 
 if __name__ == '__main__':

--- a/uncertainty_baselines/models/segmenter_test.py
+++ b/uncertainty_baselines/models/segmenter_test.py
@@ -44,6 +44,7 @@ class SegVitTest(parameterized.TestCase):
     config.backbone_configs.mlp_dim = 2
     config.backbone_configs.num_heads = 1
     config.backbone_configs.num_layers = 1
+    config.backbone_configs.classifier = 'gap'
 
     config.decoder_configs = ml_collections.ConfigDict()
     config.decoder_configs.type = 'linear'


### PR DESCRIPTION
This change Includes a new backbone (vitBE) and a new decoder  (linear+BE) for the segmenter vit model.

This change temporarily removes stochastic depth regularization (stochastic_depth flag) in segmenter to facilitate the use of vit.py and vit_batchensemble.py blocks when building new models.