### PR TITLE
add bald acquisition function

### DIFF
--- a/baselines/jft/experiments/vit_l32_active_learning_cifar.py
+++ b/baselines/jft/experiments/vit_l32_active_learning_cifar.py
@@ -27,23 +27,26 @@ def get_config():
   """Config for finetuning."""
   config = ml_collections.ConfigDict()
 
-  config.model_init = '/cns/tp-d/home/trandustin/baselines-jft-0209_205214/1/checkpoint.npz'  # pass as parameter to script
+  config.model_init = ''  # pass as parameter to script
+  config.dataset = 'cifar10'
+
   # pylint: enable=line-too-long
   config.seed = 0
 
-  n_cls = 100
+  n_cls = int(config.dataset[5:])
   size = 384
 
+  config.model_type = 'batchensemble'
+  # config.model_type = 'deterministic'
+
   # AL section:
-  config.model_type = 'deterministic'  # 'batchensemble'
-  config.acquisition_method = 'margin'
+  config.acquisition_method = 'bald'
   config.max_training_set_size = 200
   config.initial_training_set_size = 0
   config.acquisition_batch_size = 10
   config.early_stopping_patience = 64
 
   # Dataset section:
-  config.dataset = 'cifar100'
   config.val_split = 'train[98%:]'
   config.train_split = 'train[:98%]'
   config.test_split = 'test'
@@ -80,13 +83,15 @@ def get_config():
   config.model.transformer.attention_dropout_rate = 0.
   config.model.transformer.dropout_rate = 0.
   config.model.classifier = 'token'
-  # BatchEnsemble parameters.
-  config.model.transformer.be_layers = (21, 22, 23)
-  config.model.transformer.ens_size = 3
-  config.model.transformer.random_sign_init = -0.5
-  config.fast_weight_lr_multiplier = 1.0
-  # This is "no head" fine-tuning, which we use by default.
   config.model.representation_size = None
+
+  # BatchEnsemble parameters.
+  if config.model_type == 'batchensemble':
+    config.model.transformer.be_layers = (21, 22, 23)
+    config.model.transformer.ens_size = 3
+    config.model.transformer.random_sign_init = -0.5
+    config.fast_weight_lr_multiplier = 1.0
+    # This is "no head" fine-tuning, which we use by default.
 
   # Optimizer section
   config.optim_name = 'Momentum'

--- a/baselines/jft/experiments/vit_l32_active_learning_places365.py
+++ b/baselines/jft/experiments/vit_l32_active_learning_places365.py
@@ -34,6 +34,8 @@ def get_config():
   n_cls = 365
   size = 384
 
+  config.model_type = 'deterministic'
+
   # AL section:
   config.acquisition_method = 'uniform'
   config.max_training_set_size = 200


### PR DESCRIPTION
I haven't been able to run this yet. I have tried the following:

- add `__init__.py` to `baselines/jft/experiments`
- change `import sweep_utils` to `from experiments import sweep_utils`

This fixes the import crash. However I couldn't manage to run just a single job with `model_type = batchensemble` and `acquisition_method = bald` on cifar10, it seems everything goes through the sweep now (e.g. lines 40-58 of sweep_utils.py are crucial and hard to pass over command line). Did we lose the ability to run a single job?

These lines at the top of `active_learning.py` are at least no longer sufficient (even when adding `--output_dir test`):
```
python3 active_learning.py \
  --config='experiments/vit_l32_active_learning.py' \
  --config.model_init='gs://ub-checkpoints/ImageNet21k_ViT-L32/1/checkpoint.npz'
```

Reviewed-by: @BlackHC