### PR TITLE
Reduce AL TPU memory usage

### DIFF
--- a/baselines/jft/active_learning.py
+++ b/baselines/jft/active_learning.py
@@ -144,6 +144,9 @@ def get_ids_logits_masks(*,
     batch_mask = batch['mask']
     batch_output = compute_batch_outputs(opt_repl.target, batch['image'])
 
+    # This moves the batch_output from TPU to CPU right away.
+    batch_output = jax.device_put(batch_output, jax.devices("cpu")[0])
+
     # TODO(joost,andreas): if we run on multi host, we need to index
     # batch_outputs: batch_outputs[0]
     ids.append(batch_id)


### PR DESCRIPTION
Move the batch_outputs to the CPU right away.

Use device_put with a new JAX_CPU global to use JAX instead of numpy (jax.device_get converts to numpy).

This keeps the arrays pinned to the CPU with no risk of moving them back to the default device (TPU) by accident.

See https://gist.github.com/BlackHC/48e7bdd7598b51a91f51ae8af0274472 for an examination of what jax.device_put do:
it blocks by default. This is not as ideal, but so does device_get.