### PR TITLE
Fix imports in CIFAR-PI baselines

### DIFF
--- a/baselines/cifar/utils.py
+++ b/baselines/cifar/utils.py
@@ -40,7 +40,7 @@ flags.DEFINE_integer(
     'Number of epochs between evaluating on the corrupted '
     'test data. Use -1 to never evaluate.')
 flags.DEFINE_enum('dataset', 'cifar10',
-                  enum_values=['cifar10', 'cifar100'],
+                  enum_values=['cifar10', 'cifar100', 'cifar10n', 'cifar100n'],
                   help='Dataset.')
 
 flags.DEFINE_string(

--- a/baselines/privileged_information/cifar_pi/no_pi.py
+++ b/baselines/privileged_information/cifar_pi/no_pi.py
@@ -228,9 +228,6 @@ def main(argv):
       'augmix_depth': FLAGS.augmix_depth,
       'augmix_prob_coeff': FLAGS.augmix_prob_coeff,
       'augmix_width': FLAGS.augmix_width,
-      'same_mix_weight_per_batch': FLAGS.same_mix_weight_per_batch,
-      'use_random_shuffling': FLAGS.use_random_shuffling,
-      'use_truncated_beta': FLAGS.use_truncated_beta
   }
 
   # Note that stateless_{fold_in,split} may incur a performance cost, but a

--- a/baselines/privileged_information/cifar_pi/tram.py
+++ b/baselines/privileged_information/cifar_pi/tram.py
@@ -230,9 +230,6 @@ def main(argv):
       'augmix_depth': FLAGS.augmix_depth,
       'augmix_prob_coeff': FLAGS.augmix_prob_coeff,
       'augmix_width': FLAGS.augmix_width,
-      'same_mix_weight_per_batch': FLAGS.same_mix_weight_per_batch,
-      'use_random_shuffling': FLAGS.use_random_shuffling,
-      'use_truncated_beta': FLAGS.use_truncated_beta
   }
 
   # Note that stateless_{fold_in,split} may incur a performance cost, but a

--- a/uncertainty_baselines/datasets/__init__.py
+++ b/uncertainty_baselines/datasets/__init__.py
@@ -27,6 +27,8 @@ from uncertainty_baselines.datasets.base import make_ood_dataset
 from uncertainty_baselines.datasets.cifar import Cifar100Dataset
 from uncertainty_baselines.datasets.cifar import Cifar10CorruptedDataset
 from uncertainty_baselines.datasets.cifar import Cifar10Dataset
+from uncertainty_baselines.datasets.cifar import Cifar10NDataset
+from uncertainty_baselines.datasets.cifar import Cifar100NDataset
 from uncertainty_baselines.datasets.cifar100_corrupted import Cifar100CorruptedDataset
 from uncertainty_baselines.datasets.cityscapes import CityscapesDataset
 from uncertainty_baselines.datasets.cityscapes_corrupted import CityscapesCorruptedDataset

--- a/uncertainty_baselines/datasets/datasets.py
+++ b/uncertainty_baselines/datasets/datasets.py
@@ -28,6 +28,8 @@ from uncertainty_baselines.datasets.base import BaseDataset
 from uncertainty_baselines.datasets.cifar import Cifar100Dataset
 from uncertainty_baselines.datasets.cifar import Cifar10CorruptedDataset
 from uncertainty_baselines.datasets.cifar import Cifar10Dataset
+from uncertainty_baselines.datasets.cifar import Cifar10NDataset
+from uncertainty_baselines.datasets.cifar import Cifar100NDataset
 from uncertainty_baselines.datasets.cifar100_corrupted import Cifar100CorruptedDataset
 from uncertainty_baselines.datasets.cityscapes import CityscapesDataset
 from uncertainty_baselines.datasets.clinc_intent import ClincIntentDetectionDataset
@@ -88,6 +90,8 @@ DATASETS = {
     'aptos': APTOSDataset,
     'cifar100': Cifar100Dataset,
     'cifar10': Cifar10Dataset,
+    'cifar10n': Cifar10NDataset,
+    'cifar100n': Cifar100NDataset,
     'cifar10_corrupted': Cifar10CorruptedDataset,
     'cifar100_corrupted': Cifar100CorruptedDataset,
     'cityscapes': CityscapesDataset,


### PR DESCRIPTION
I have spotted a few issues in the new baselines in `baselines/privileged_information/cifar_pi`:

1. The local imports in the baselines (e.g., utils.py, ood_utils.py, pi_utils.py) are not recognised when you run as suggested in the `README.md`. 
2. The new datasets are not listed in `uncertainty_baselines/datasets/datasets.py` and `uncertainty_baselines/datasets/__init__.py`.
3. `cifar10n` and `cifar100n` are not allowed options of `FLAGS.dataset`.
4. The new augmix flags are not declared anywhere.

Issues 2., 3., and 4. should be fixed by this PR, but the local imports in 1. need to be fixed. This will probably require some restructuring of the `baselines` directory, either duplicating the utils files inside `cifar_pi` or working out the relative imports explicitly.